### PR TITLE
(feat) Blacklist Non-Validator, and Rate-Limit Validator Based on Tao

### DIFF
--- a/sd_net/base_miner/config.yaml
+++ b/sd_net/base_miner/config.yaml
@@ -2,6 +2,6 @@ blacklist:
   min_stake: 1000
   block_non_validator: True
   tao_based_limitation:
-    tao_base_level: 500 # TAOs
-    interval: 6000 # seconds
+    tao_base_level: 1000 # TAOs
+    interval: 600 # seconds
     max_requests_per_interval: 10

--- a/sd_net/base_miner/config.yaml
+++ b/sd_net/base_miner/config.yaml
@@ -1,0 +1,7 @@
+blacklist:
+  min_stake: 1000
+  block_non_validator: True
+  tao_based_limitation:
+    tao_base_level: 500 # TAOs
+    interval: 6000 # seconds
+    max_requests_per_interval: 10

--- a/sd_net/base_miner/miner.py
+++ b/sd_net/base_miner/miner.py
@@ -104,7 +104,7 @@ class Miner(BaseMinerNeuron):
             f"Not Blacklisting recognized hotkey {synapse.dendrite.hotkey}"
         )
         validator_uid = self.metagraph.hotkeys.index( synapse.dendrite.hotkey )
-        stake = self.metagraph.stake[validator_uid]
+        stake = self.metagraph.stake[validator_uid].item()
         if stake < CONFIG['blacklist']['min_stake']:
             return True, "Validator doesn't have enough stake"
         if self.check_limit(uid=validator_uid, stake=stake):

--- a/sd_net/base_miner/miner.py
+++ b/sd_net/base_miner/miner.py
@@ -14,7 +14,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 GENERATE_URL = os.getenv("MINER_SD_ENDPOINT")
-CONFIG = yaml.load(open("./config.yaml"), Loader=yaml.FullLoader)
+CONFIG = yaml.load(open("sd_net/base_miner/config.yaml"), Loader=yaml.FullLoader)
 
 def calculate_max_request_per_interval(stake: int):
     return CONFIG['blacklist']['tao_based_limitation']['max_requests_per_interval'] \
@@ -109,6 +109,9 @@ class Miner(BaseMinerNeuron):
             return True, "Validator doesn't have enough stake"
         if self.check_limit(uid=validator_uid, stake=stake):
             return True, "Limit exceeded"
+        bt.logging.trace(
+            f"Passed all blacklist checking!"
+        )
         return False, "All passed!"
 
 

--- a/sd_net/base_miner/miner.py
+++ b/sd_net/base_miner/miner.py
@@ -11,34 +11,36 @@ import time
 import requests
 import yaml
 from dotenv import load_dotenv
+
 load_dotenv()
 
 GENERATE_URL = os.getenv("MINER_SD_ENDPOINT")
 CONFIG = yaml.load(open("sd_net/base_miner/config.yaml"), Loader=yaml.FullLoader)
 
+
 def calculate_max_request_per_interval(stake: int):
-    return CONFIG['blacklist']['tao_based_limitation']['max_requests_per_interval'] \
-        * (stake \
-            // CONFIG['blacklist']['tao_based_limitation']['tao_base_level'])
+    return CONFIG["blacklist"]["tao_based_limitation"]["max_requests_per_interval"] * (
+        stake // CONFIG["blacklist"]["tao_based_limitation"]["tao_base_level"]
+    )
 
 
 class Miner(BaseMinerNeuron):
     def __init__(self, config=None):
         super(Miner, self).__init__(config=config)
         self.validator_logs = {}
-        
+
     def generate(self, prompt: str, seed: int, additional_params: dict) -> List[str]:
         data = {"prompt": prompt, "seed": seed, "additional_params": additional_params}
 
         headers = {
-            'accept': 'application/json',
-            'Content-Type': 'application/json',
+            "accept": "application/json",
+            "Content-Type": "application/json",
         }
 
         response = requests.post(GENERATE_URL, headers=headers, json=data)
-        images = response.json()['images']
+        images = response.json()["images"]
         return images
-    
+
     async def forward(
         self, synapse: sd_net.protocol.ImageGenerating
     ) -> sd_net.protocol.ImageGenerating:
@@ -47,6 +49,7 @@ class Miner(BaseMinerNeuron):
         synapse.images = images
 
         return synapse
+
     def check_limit(self, uid: str, stake: int):
         current_time = time.time()
         print(self.validator_logs)
@@ -56,7 +59,10 @@ class Miner(BaseMinerNeuron):
                 "max_request": calculate_max_request_per_interval(stake=stake),
                 "request_counter": 1,
             }
-        elif time.time() - self.validator_logs[uid]['start_interval'] > CONFIG['blacklist']['tao_based_limitation']['interval']:
+        elif (
+            time.time() - self.validator_logs[uid]["start_interval"]
+            > CONFIG["blacklist"]["tao_based_limitation"]["interval"]
+        ):
             self.validator_logs[uid] = {
                 "start_interval": time.time(),
                 "max_request": calculate_max_request_per_interval(stake=stake),
@@ -64,10 +70,14 @@ class Miner(BaseMinerNeuron):
             }
             print(f"RESET INTERVAL OF {uid}")
         else:
-            self.validator_logs[uid]['request_counter'] += 1
-            if self.validator_logs[uid]['request_counter'] > self.validator_logs[uid]['max_request']:
+            self.validator_logs[uid]["request_counter"] += 1
+            if (
+                self.validator_logs[uid]["request_counter"]
+                > self.validator_logs[uid]["max_request"]
+            ):
                 return True
         return False
+
     async def blacklist(
         self, synapse: sd_net.protocol.ImageGenerating
     ) -> typing.Tuple[bool, str]:
@@ -111,9 +121,9 @@ class Miner(BaseMinerNeuron):
         bt.logging.trace(
             f"Not Blacklisting recognized hotkey {synapse.dendrite.hotkey}"
         )
-        validator_uid = self.metagraph.hotkeys.index( synapse.dendrite.hotkey )
+        validator_uid = self.metagraph.hotkeys.index(synapse.dendrite.hotkey)
         stake = self.metagraph.stake[validator_uid].item()
-        if stake < CONFIG['blacklist']['min_stake']:
+        if stake < CONFIG["blacklist"]["min_stake"]:
             bt.logging.trace(
                 f"Blacklisting {validator_uid}-validator has {stake} stake"
             )
@@ -122,7 +132,6 @@ class Miner(BaseMinerNeuron):
             return True, "Limit exceeded"
 
         return False, "All passed!"
-
 
     async def priority(self, synapse: sd_net.protocol.ImageGenerating) -> float:
         """
@@ -155,6 +164,7 @@ class Miner(BaseMinerNeuron):
             f"Prioritizing {synapse.dendrite.hotkey} with value: ", prirority
         )
         return prirority
+
 
 # This is the main function, which runs the miner.
 if __name__ == "__main__":

--- a/sd_net/base_miner/miner.py
+++ b/sd_net/base_miner/miner.py
@@ -1,9 +1,7 @@
 import time
 import typing
 import bittensor as bt
-import template
 from template.base.miner import BaseMinerNeuron
-from diffusers import StableDiffusionXLPipeline
 import sd_net
 import torch
 from sd_net.protocol import pil_image_to_base64

--- a/sd_net/base_miner/miner.py
+++ b/sd_net/base_miner/miner.py
@@ -58,8 +58,8 @@ class Miner(BaseMinerNeuron):
             self.validator_logs[uid]['request_counter'] += 1
             if self.validator_logs[uid]['request_counter'] > self.validator_logs[uid]['max_request']:
                 self.validator_logs.pop(uid, None)
-                return False
-        return True
+                return True
+        return False
     async def blacklist(
         self, synapse: sd_net.protocol.ImageGenerating
     ) -> typing.Tuple[bool, str]:
@@ -110,8 +110,9 @@ class Miner(BaseMinerNeuron):
                 f"Blacklisting {validator_uid}-validator has {stake} stake"
             )
             return True, "Validator doesn't have enough stake"
-        # if self.check_limit(uid=validator_uid, stake=stake):
-        #     return True, "Limit exceeded"
+        if self.check_limit(uid=validator_uid, stake=stake):
+
+            return True, "Limit exceeded"
         return False, "All passed!"
 
 

--- a/sd_net/base_miner/miner.py
+++ b/sd_net/base_miner/miner.py
@@ -92,26 +92,23 @@ class Miner(BaseMinerNeuron):
 
         Otherwise, allow the request to be processed further.
         """
-        # TODO(developer): Define how miners should blacklist requests.
-        if synapse.dendrite.hotkey not in self.metagraph.hotkeys:
-            # Ignore requests from unrecognized entities.
-            bt.logging.trace(
-                f"Blacklisting unrecognized hotkey {synapse.dendrite.hotkey}"
-            )
-            return True, "Unrecognized hotkey"
+        # # TODO(developer): Define how miners should blacklist requests.
+        # if synapse.dendrite.hotkey not in self.metagraph.hotkeys:
+        #     # Ignore requests from unrecognized entities.
+        #     bt.logging.trace(
+        #         f"Blacklisting unrecognized hotkey {synapse.dendrite.hotkey}"
+        #     )
+        #     return True, "Unrecognized hotkey"
 
-        bt.logging.trace(
-            f"Not Blacklisting recognized hotkey {synapse.dendrite.hotkey}"
-        )
-        validator_uid = self.metagraph.hotkeys.index( synapse.dendrite.hotkey )
-        stake = self.metagraph.stake[validator_uid].item()
-        if stake < CONFIG['blacklist']['min_stake']:
-            return True, "Validator doesn't have enough stake"
-        if self.check_limit(uid=validator_uid, stake=stake):
-            return True, "Limit exceeded"
-        bt.logging.trace(
-            f"Passed all blacklist checking!"
-        )
+        # bt.logging.trace(
+        #     f"Not Blacklisting recognized hotkey {synapse.dendrite.hotkey}"
+        # )
+        # validator_uid = self.metagraph.hotkeys.index( synapse.dendrite.hotkey )
+        # stake = self.metagraph.stake[validator_uid].item()
+        # if stake < CONFIG['blacklist']['min_stake']:
+        #     return True, "Validator doesn't have enough stake"
+        # if self.check_limit(uid=validator_uid, stake=stake):
+        #     return True, "Limit exceeded"
         return False, "All passed!"
 
 

--- a/sd_net/base_miner/miner.py
+++ b/sd_net/base_miner/miner.py
@@ -93,20 +93,23 @@ class Miner(BaseMinerNeuron):
         Otherwise, allow the request to be processed further.
         """
         # # TODO(developer): Define how miners should blacklist requests.
-        # if synapse.dendrite.hotkey not in self.metagraph.hotkeys:
-        #     # Ignore requests from unrecognized entities.
-        #     bt.logging.trace(
-        #         f"Blacklisting unrecognized hotkey {synapse.dendrite.hotkey}"
-        #     )
-        #     return True, "Unrecognized hotkey"
+        if synapse.dendrite.hotkey not in self.metagraph.hotkeys:
+            # Ignore requests from unrecognized entities.
+            bt.logging.trace(
+                f"Blacklisting unrecognized hotkey {synapse.dendrite.hotkey}"
+            )
+            return True, "Unrecognized hotkey"
 
-        # bt.logging.trace(
-        #     f"Not Blacklisting recognized hotkey {synapse.dendrite.hotkey}"
-        # )
-        # validator_uid = self.metagraph.hotkeys.index( synapse.dendrite.hotkey )
-        # stake = self.metagraph.stake[validator_uid].item()
-        # if stake < CONFIG['blacklist']['min_stake']:
-        #     return True, "Validator doesn't have enough stake"
+        bt.logging.trace(
+            f"Not Blacklisting recognized hotkey {synapse.dendrite.hotkey}"
+        )
+        validator_uid = self.metagraph.hotkeys.index( synapse.dendrite.hotkey )
+        stake = self.metagraph.stake[validator_uid].item()
+        if stake < CONFIG['blacklist']['min_stake']:
+            bt.logging.trace(
+                f"Blacklisting {validator_uid}-validator has {stake} stake"
+            )
+            return True, "Validator doesn't have enough stake"
         # if self.check_limit(uid=validator_uid, stake=stake):
         #     return True, "Limit exceeded"
         return False, "All passed!"

--- a/sd_net/base_miner/miner_api.py
+++ b/sd_net/base_miner/miner_api.py
@@ -6,23 +6,30 @@ from typing import List
 from utils import pil_image_to_base64, base64_to_pil_image
 from pydantic import BaseModel
 
+
 class Prompt(BaseModel):
     prompt: str
     seed: int
     additional_params: dict = {}
+
 
 app = FastAPI()
 pipe = StableDiffusionPipeline.from_single_file("model.safetensors")
 pipe.enable_model_cpu_offload()
 pipe.to("cuda")
 
+
 @app.post("/generate")
 async def get_rewards(data: Prompt):
     generator = torch.Generator().manual_seed(data.seed)
-    images = pipe(prompt=data.prompt, generator=generator, **data.additional_params).images
+    images = pipe(
+        prompt=data.prompt, generator=generator, **data.additional_params
+    ).images
     images = [pil_image_to_base64(image) for image in images]
     return {"images": images}
 
+
 if __name__ == "__main__":
     import uvicorn
+
     uvicorn.run(app, host="0.0.0.0", port=10001)

--- a/sd_net/base_miner/utils.py
+++ b/sd_net/base_miner/utils.py
@@ -3,15 +3,17 @@ import numpy as np
 import base64
 from PIL import Image
 
+
 def pil_image_to_base64(image: Image.Image) -> str:
-    image_stream = io.BytesIO()    
-    image.save(image_stream, format="PNG")    
-    base64_image = base64.b64encode(image_stream.getvalue()).decode('utf-8')
-    
+    image_stream = io.BytesIO()
+    image.save(image_stream, format="PNG")
+    base64_image = base64.b64encode(image_stream.getvalue()).decode("utf-8")
+
     return base64_image
+
 
 def base64_to_pil_image(base64_image: str) -> Image.Image:
     image_stream = io.BytesIO(base64.b64decode(base64_image))
     image = Image.open(image_stream)
-    
+
     return image

--- a/sd_net/protocol.py
+++ b/sd_net/protocol.py
@@ -6,17 +6,18 @@ from PIL import Image
 import io
 import base64
 
+
 def pil_image_to_base64(image):
-    image_stream = io.BytesIO()    
-    image.save(image_stream, format="PNG")    
-    base64_image = base64.b64encode(image_stream.getvalue()).decode('utf-8')
-    
+    image_stream = io.BytesIO()
+    image.save(image_stream, format="PNG")
+    base64_image = base64.b64encode(image_stream.getvalue()).decode("utf-8")
+
     return base64_image
 
 
 class ImageGenerating(bt.Synapse):
     prompt: str = pydantic.Field(
-        default = "",
+        default="",
         title="Prompt",
         description="Requested prompt for text to image generating",
     )
@@ -27,7 +28,9 @@ class ImageGenerating(bt.Synapse):
         default=[], title="Images", description="Output of text to image model"
     )
     pipeline_params: dict = pydantic.Field(
-        default={}, title="Pipeline Parameters", description="Additional generating params"
+        default={},
+        title="Pipeline Parameters",
+        description="Additional generating params",
     )
 
     def deserialize(self) -> typing.List[str]:


### PR DESCRIPTION
There is a risk that some validators might spam miners and cause them to get overloaded. Therefore there should be clear and strict limits on the number of requests that can be sent to a miner from a single validator.

The following rules should be implemented:

1. Miners should only accept requests from validators with at least 10 000 TAO.
2. For each 10k Tao, validators can send an additional 10 requests every 10 minutes to a single miner. Thus a validator with 100 000 Tao can send  100 requests every 10 minutes to a single miner.
